### PR TITLE
RDKB-64705:Copy github workflow from develop to main branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @rdkcentral/rdkb-hal-advisory @rdkcentral/vendor-layer-advisory  
+*       @rdkcentral/rdkb-hal-advisory @rdkcentral/vendor-layer-advisory  @rdkcentral/rdkb-maintainers

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,20 @@
+name: "CLA"
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: write
+  statuses: write
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+jobs:
+  CLA-Lite:
+    name: "Signature"
+    uses: rdkcentral/cmf-actions/.github/workflows/cla.yml@v1
+    secrets:
+      PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ASSISTANT }}


### PR DESCRIPTION
Bring the github workflow (cla.yml) on develop branch (develop/.github/workflows/cla.yml) to main branch for below repos if not already present for CLA check to run.